### PR TITLE
fix : removed unnecessary text from [sidebar]

### DIFF
--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -278,12 +278,7 @@ export default function Sidebar() {
             <TooltipContent side="right">Settings</TooltipContent>
           )}
         </Tooltip>
-        <div className="text-xs flex pt-2">
-          <a href="/privacy-policy">Privacy Policy</a>
-          <a href="/terms-of-service">Terms of Services</a>
-          <a href="/cookie-policy">Cookies Policy</a>
-          <a href="/dmca-policy">DMCA Policy</a>
-        </div>
+      
       </div>
     </div>
   );


### PR DESCRIPTION
Removed unnecessary text for better clarity from Sidebar .
Before : 
<img width="327" height="712" alt="Screenshot 2025-07-26 185144" src="https://github.com/user-attachments/assets/ff43e2c0-7210-4ce2-9719-7f6f7d5dba60" />

After :
<img width="342" height="762" alt="Screenshot 2025-07-26 192644" src="https://github.com/user-attachments/assets/df74850a-cbc0-413b-a5d8-9d5aee7b83c1" />

