### PR TITLE
feat: add NativeBannerAd to all tool pages as per layout guidelines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.1",
         "@hookform/resolvers": "^5.1.1",
         "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-alert-dialog": "^1.1.14",

--- a/src/app/(Tools)/ai-bio-generator/components/bio-generator-client.tsx
+++ b/src/app/(Tools)/ai-bio-generator/components/bio-generator-client.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from "react";
 import BioGeneratorForm from "./bio-generator-form";
 import BioGeneratorOutput from "./bio-generator-output";
-
+import NativeBannerAd from "@/components/NativeBannerAd";
 const BioGeneratorClient = () => {
   const [output, setOutput] = useState("");
   const [loading, setLoading] = useState(false);
@@ -54,6 +54,10 @@ const BioGeneratorClient = () => {
       {loading && <p className="text-blue-500 mt-4">Generating...</p>}
       {error && <p className="text-red-500 mt-4">{error}</p>}
       <BioGeneratorOutput output={output} isLoading={loading} />
+                
+      {/* Ad Banner */}
+     <NativeBannerAd />
+
 
        <div className="text-sm text-gray-600 mt-20  mx-auto">
   <h3 className="font-bold text-lg mb-2">Why Our Users Love It:</h3>

--- a/src/app/(Tools)/ai-translator/_components/translator-client.tsx
+++ b/src/app/(Tools)/ai-translator/_components/translator-client.tsx
@@ -25,6 +25,7 @@ import {
 } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-mobile";
 import Link from "next/link";
+import NativeBannerAd from "@/components/NativeBannerAd";
 
 export default function TranslatorClient() {
   const [translatedText, setTranslatedText] = useState("");
@@ -205,6 +206,9 @@ ${data.text}
                 </CollapsibleContent>
               </Collapsible>
             </div>
+            {/* Ad Banner */}
+            <NativeBannerAd />
+
             <article className="prose max-w-none mb-8">
               <h1 className="text-3xl font-bold mb-4 flex items-center gap-2">
                 <FileEdit className="h-6 w-6 text-primary" />

--- a/src/app/(Tools)/anime-ai-generator/_components/anime-generator-client.tsx
+++ b/src/app/(Tools)/anime-ai-generator/_components/anime-generator-client.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from "react";
 import AnimeGeneratorForm from "./anime-generator-form";
 import AnimeGeneratorOutput from "./anime-generator-output";
-
+import NativeBannerAd from "@/components/NativeBannerAd";
 export interface AnimeGenerationOptions {
   style: string;
   ratio: string;
@@ -81,6 +81,7 @@ export default function AnimeGeneratorClient() {
   };
 
   return (
+    <>
     <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
       <div className="md:col-span-1">
         <AnimeGeneratorForm
@@ -101,7 +102,12 @@ export default function AnimeGeneratorClient() {
           ratio={options.ratio}
         />
       </div>
+      
     </div>
+    {/* Ad Banner */}
+    <NativeBannerAd />
+
+    </>
   );
 }
 

--- a/src/app/(Tools)/app-idea-generator/_components/app-idea-generator-client.tsx
+++ b/src/app/(Tools)/app-idea-generator/_components/app-idea-generator-client.tsx
@@ -14,7 +14,7 @@ import { Button } from "@/components/ui/button"
 import { ChevronsUpDown, Sparkles, Zap, Smartphone, Rocket, Lightbulb, Code } from "lucide-react"
 import { useIsMobile } from "@/hooks/use-mobile"
 import Link from "next/link"
-
+import NativeBannerAd from "@/components/NativeBannerAd";
 export default function AppIdeaGeneratorClient() {
   const [generatedIdeas, setGeneratedIdeas] = useState("")
   const [isLoading, setIsLoading] = useState(false)
@@ -227,6 +227,7 @@ Please provide 5 well-structured mobile app ideas with names, descriptions, feat
                 </div>
               )}
               
+              
               <CollapsibleContent className="rounded-b-lg border border-t-0 p-4 data-[state=closed]:hidden">
                 <div className="space-y-4">
                   {isLoading && (
@@ -256,6 +257,9 @@ Please provide 5 well-structured mobile app ideas with names, descriptions, feat
           </div>
         </main>
       </div>
+      {/* Ad Banner */}
+     <NativeBannerAd />
+
     </div>
   )
 }

--- a/src/app/(Tools)/blog-idea-generator/_components/blog-idea-generator-client.tsx
+++ b/src/app/(Tools)/blog-idea-generator/_components/blog-idea-generator-client.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button"
 import { ChevronsUpDown, Sparkles, Zap, PenTool, BookOpen, FileText, Newspaper } from "lucide-react"
 import { useIsMobile } from "@/hooks/use-mobile"
 import Link from "next/link"
+import NativeBannerAd from "@/components/NativeBannerAd";
 
 export default function BlogIdeaGeneratorClient() {
   const [generatedIdeas, setGeneratedIdeas] = useState("")
@@ -199,7 +200,7 @@ Please provide 10 well-structured blog post ideas with headlines, descriptions, 
           <div>
             <BlogIdeaGeneratorForm onSubmit={handleFormSubmit} isLoading={isLoading} />
           </div>
-
+          
           <div ref={outputRef}>
             <Collapsible
               open={isOutputOpen}
@@ -253,6 +254,9 @@ Please provide 10 well-structured blog post ideas with headlines, descriptions, 
           </div>
         </main>
       </div>
+      {/* Ad Banner */}
+     <NativeBannerAd />
+
     </div>
   )
 }

--- a/src/app/(Tools)/blog-writer/_components/blog-writer-client.tsx
+++ b/src/app/(Tools)/blog-writer/_components/blog-writer-client.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import BlogWriterForm from "./blog-writer-form";
 import BlogWriterOutput from "./blog-writer-output";
 import { toast } from "sonner";
-
+import NativeBannerAd from "@/components/NativeBannerAd";
 export interface BlogWriterResult {
   title: string;
   content: string;
@@ -119,8 +119,11 @@ export default function BlogWriterClient() {
               </CardContent>
             </Card>
           </div>
-        </TabsContent>
         
+        </TabsContent>
+        {/* Ad Banner */}
+        <NativeBannerAd />
+
         <TabsContent value="about">
           <Card>
             <CardHeader>

--- a/src/app/(Tools)/code-explainer/code-explainer-client.tsx
+++ b/src/app/(Tools)/code-explainer/code-explainer-client.tsx
@@ -3,6 +3,7 @@
 import React, { useState,JSX } from 'react';
 import CodeExplainerInput from './code-explainer-input';
 import CodeExplainerOutput from './code-explainer-output';
+import NativeBannerAd from '@/components/NativeBannerAd';
 
 interface FormData {
   code: string;
@@ -29,6 +30,7 @@ export default function CodeExplainerClient(): JSX.Element {
         currentFormData={currentFormData}
         setCurrentFormData={setCurrentFormData}
       />
+      
 
       {/* Output Component */}
       <CodeExplainerOutput
@@ -40,6 +42,9 @@ export default function CodeExplainerClient(): JSX.Element {
         setIsLoading={setIsLoading}
         setError={setError}
       />
+      {/* Ad Banner */}
+        <NativeBannerAd />
+
     </>
   );
 }

--- a/src/app/(Tools)/email-writer/_components/email-writer-client.tsx
+++ b/src/app/(Tools)/email-writer/_components/email-writer-client.tsx
@@ -13,7 +13,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { ChevronsUpDown, Mail, Star, Clock, ThumbsUp, Send, Settings, AlertCircle, RefreshCw, HelpCircle, FileEdit, User, FileText } from "lucide-react"
 import { useIsMobile } from "@/hooks/use-mobile"
-
+import NativeBannerAd from "@/components/NativeBannerAd";
 export default function EmailWriterClient() {
   const [generatedEmail, setGeneratedEmail] = useState("")
   const [isLoading, setIsLoading] = useState(false)
@@ -99,7 +99,7 @@ export default function EmailWriterClient() {
         <h2 className="sr-only">Email Generation Form</h2>
         <EmailWriterForm onSubmit={handleFormSubmit} isLoading={isLoading} />
       </section>
-
+  
       <div ref={outputRef} className="mt-6">
         <Collapsible
           open={isOutputOpen}
@@ -154,6 +154,9 @@ export default function EmailWriterClient() {
           </CollapsibleContent>
         </Collapsible>
       </div>
+      {/* Ad Banner */}
+      <NativeBannerAd />
+
       <article className="prose max-w-none mb-8">
         <h1 className="text-3xl font-bold mb-4 flex items-center gap-2">
           <FileEdit className="h-6 w-6 text-primary" />

--- a/src/app/(Tools)/grammar-fixer/_components/grammar-fixer-client.tsx
+++ b/src/app/(Tools)/grammar-fixer/_components/grammar-fixer-client.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import GrammarFixerForm from "./grammar-fixer-form";
 import GrammarFixerOutput from "./grammar-fixer-output";
 import { toast } from "sonner";
-
+import NativeBannerAd from "@/components/NativeBannerAd";
 export interface GrammarFixerResult {
   originalText: string;
   correctedText: string;
@@ -128,7 +128,9 @@ export default function GrammarFixerClient() {
             </Card>
           </div>
         </TabsContent>
-        
+        {/* Ad Banner */}
+       <NativeBannerAd />
+
         <TabsContent value="about">
           <Card>
             <CardHeader>

--- a/src/app/(Tools)/idea-generator/_components/idea-generator-client.tsx
+++ b/src/app/(Tools)/idea-generator/_components/idea-generator-client.tsx
@@ -14,7 +14,7 @@ import { Button } from "@/components/ui/button"
 import { ChevronsUpDown, Sparkles, Zap, Rocket, Youtube, PenTool, Smartphone, Package } from "lucide-react"
 import { useIsMobile } from "@/hooks/use-mobile"
 import Link from "next/link"
-
+import NativeBannerAd from "@/components/NativeBannerAd";
 export default function IdeaGeneratorClient() {
   const [generatedIdea, setGeneratedIdea] = useState("")
   const [isLoading, setIsLoading] = useState(false)
@@ -281,6 +281,7 @@ Please provide a comprehensive, well-structured idea that addresses all these re
   }, [generatedIdea, error, isMobile]);
 
   return (
+    <>
     <div className="container mx-auto p-4 md:p-6 lg:p-8">
       <div className="max-w-6xl mx-auto">
         <header className="text-center mb-8 md:mb-10 relative">
@@ -380,9 +381,15 @@ Please provide a comprehensive, well-structured idea that addresses all these re
                 </div>
               </CollapsibleContent>
             </Collapsible>
+             
           </div>
         </main>
       </div>
+     
+
     </div>
+    {/* Ad Banner */}
+      <NativeBannerAd />
+    </>
   )
 }

--- a/src/app/(Tools)/image-generator/_components/image-generator-client.tsx
+++ b/src/app/(Tools)/image-generator/_components/image-generator-client.tsx
@@ -4,6 +4,8 @@ import React, { useState } from "react";
 import ImageGeneratorForm from "./image-generator-form";
 import ImageGeneratorOutput from "./image-generator-output";
 
+import NativeBannerAd from "@/components/NativeBannerAd";
+
 export interface ImageGenerationOptions {
   style: string;
   ratio: string;
@@ -76,6 +78,7 @@ export default function ImageGeneratorClient() {
   };
 
   return (
+    <>
     <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
       <div className="md:col-span-1">
         <ImageGeneratorForm
@@ -96,6 +99,11 @@ export default function ImageGeneratorClient() {
           ratio={options.ratio}
         />
       </div>
+    
     </div>
+      {/* Ad Banner */}
+      <NativeBannerAd />
+
+    </>
   );
 } 

--- a/src/app/(Tools)/linkedin-post-generator/_components/linkedin-post-generator-client.tsx
+++ b/src/app/(Tools)/linkedin-post-generator/_components/linkedin-post-generator-client.tsx
@@ -13,7 +13,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { ChevronsUpDown, Linkedin, Star, Clock, ThumbsUp, Copy, Settings, AlertCircle, RefreshCw, HelpCircle, FileEdit, User, FileText } from "lucide-react"
 import { useIsMobile } from "@/hooks/use-mobile"
-
+import NativeBannerAd from "@/components/NativeBannerAd";
 export default function LinkedInPostGeneratorClient() {
   const [generatedPost, setGeneratedPost] = useState("")
   const [isLoading, setIsLoading] = useState(false)
@@ -154,6 +154,8 @@ export default function LinkedInPostGeneratorClient() {
           </CollapsibleContent>
         </Collapsible>
       </div>
+       {/* Ad Banner */}
+      <NativeBannerAd />
       <article className="prose max-w-none mb-8">
         <h1 className="text-3xl font-bold mb-4 flex items-center gap-2">
           <FileEdit className="h-6 w-6 text-primary" />

--- a/src/app/(Tools)/logo-generator/_components/logo-generator-client.tsx
+++ b/src/app/(Tools)/logo-generator/_components/logo-generator-client.tsx
@@ -9,7 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Input } from "@/components/ui/input";
 import { Sparkles, Zap, Users, Shield, Award, Download, Loader2, Info, Lightbulb } from "lucide-react";
 import Image from 'next/image';
-
+import NativeBannerAd from "@/components/NativeBannerAd";
 export default function LogoGeneratorClient() {
   const [isGenerating, setIsGenerating] = useState(false);
   const [generatedLogo, setGeneratedLogo] = useState<string | null>(null);
@@ -205,7 +205,6 @@ export default function LogoGeneratorClient() {
                   )}
                 </Button>
               </form>
-
               {/* Examples */}
               <div className="mt-6 p-4 bg-gray-50 rounded-lg">
                 <h3 className="font-medium text-sm text-gray-700 mb-2 flex items-center gap-2">
@@ -293,6 +292,8 @@ export default function LogoGeneratorClient() {
             </CardContent>
           </Card>
         </div>
+      {/* Ad Banner */}
+      <NativeBannerAd />
 
         {/* Comprehensive Guide Section */}
         <div className="mt-16 space-y-8">

--- a/src/app/(Tools)/product-idea-generator/_components/product-idea-generator-client.tsx
+++ b/src/app/(Tools)/product-idea-generator/_components/product-idea-generator-client.tsx
@@ -23,7 +23,7 @@ import {
 } from "lucide-react"
 import { useIsMobile } from "@/hooks/use-mobile"
 import Link from "next/link"
-
+import NativeBannerAd from "@/components/NativeBannerAd";
 export default function ProductIdeaGeneratorClient() {
   const [generatedIdeas, setGeneratedIdeas] = useState("")
   const [isLoading, setIsLoading] = useState(false)
@@ -234,6 +234,9 @@ Format each idea with clear sections using markdown headers (##) and bullet poin
             </div>
           </div>
         )}
+        
+      {/* Ad Banner */}
+      <NativeBannerAd />
 
         {/* SEO Content - Server-side rendered */}
         <div className="mt-12 prose prose-gray max-w-none">

--- a/src/app/(Tools)/project-recommender/_components/project-recommender-client.tsx
+++ b/src/app/(Tools)/project-recommender/_components/project-recommender-client.tsx
@@ -13,7 +13,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { ChevronsUpDown, Target, Zap, Code, Rocket, Trophy, Layers, Brain } from "lucide-react"
 import { useIsMobile } from "@/hooks/use-mobile"
-
+import NativeBannerAd from "@/components/NativeBannerAd";
 export default function ProjectRecommenderClient() {
   const [generatedProjects, setGeneratedProjects] = useState("")
   const [isLoading, setIsLoading] = useState(false)
@@ -215,7 +215,12 @@ ${data.additionalRequirements ? `- Additional Requirements: ${data.additionalReq
             </Collapsible>
           </div>
         </main>
+        {/* Ad Banner */}
+      <NativeBannerAd />
       </div>
+      
+    
+
     </div>
   )
 }

--- a/src/app/(Tools)/prompt-generator/_components/prompt-generator-client.tsx
+++ b/src/app/(Tools)/prompt-generator/_components/prompt-generator-client.tsx
@@ -13,7 +13,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { ChevronsUpDown, Brain } from "lucide-react"
 import { useIsMobile } from "@/hooks/use-mobile"
-
+import NativeBannerAd from "@/components/NativeBannerAd";
 export default function PromptGeneratorClient() {
   const [generatedPrompt, setGeneratedPrompt] = useState("")
   const [isLoading, setIsLoading] = useState(false)
@@ -453,6 +453,9 @@ Make it immediately deployable and significantly more effective than the origina
           </CollapsibleContent>
         </Collapsible>
       </div>
+      {/* Ad Banner */}
+      <NativeBannerAd />
+
     </div>
   )
 }

--- a/src/app/(Tools)/resume-builder/_components/Resume-builder-client.tsx
+++ b/src/app/(Tools)/resume-builder/_components/Resume-builder-client.tsx
@@ -8,7 +8,7 @@ import { initialResumeValues } from "../constant";
 import ResumePreviewSection from "./ResumePreviewSection";
 import { useResume } from "@/contexts/resume-context";
 import Loader from "./Loader";
-
+import NativeBannerAd from "@/components/NativeBannerAd";
 // Debounce function
 const debounce = (func: Function, delay: number) => {
   let timeoutId: NodeJS.Timeout;
@@ -107,7 +107,9 @@ export default function ResumeBuilder() {
             </div>
           )}
         </div>
-
+      {/* Ad Banner */}
+      <NativeBannerAd />
+         
        
       </div>
     </>

--- a/src/app/(Tools)/startup-idea-generator/_components/startup-idea-generator-client.tsx
+++ b/src/app/(Tools)/startup-idea-generator/_components/startup-idea-generator-client.tsx
@@ -14,7 +14,7 @@ import { Button } from "@/components/ui/button"
 import { ChevronsUpDown, Rocket, Lightbulb, Zap, Briefcase } from "lucide-react"
 import { useIsMobile } from "@/hooks/use-mobile"
 import Link from "next/link"
-
+import NativeBannerAd from "@/components/NativeBannerAd";
 export default function StartupIdeaGeneratorClient() {
   const [generatedIdeas, setGeneratedIdeas] = useState("")
   const [isLoading, setIsLoading] = useState(false)
@@ -196,7 +196,10 @@ Format each idea with clear sections using markdown headers (##) and bullet poin
         <div className="w-full">
           <StartupIdeaOutput generatedIdeas={generatedIdeas} isLoading={isLoading} />
         </div>
+        {/* Ad Banner */}
+           <NativeBannerAd />
 
+          
         {/* Related Tools */}
         {!isLoading && generatedIdeas && (
           <div className="mt-8">

--- a/src/app/(Tools)/text-summarizer/_components/text-summarizer-client.tsx
+++ b/src/app/(Tools)/text-summarizer/_components/text-summarizer-client.tsx
@@ -4,7 +4,7 @@ import { useState } from "react"
 import { toast } from "sonner"
 import { TextSummarizerForm, FormValues } from "./text-summarizer-form"
 import { TextSummarizerOutput } from "./text-summarizer-output"
-
+import NativeBannerAd from "@/components/NativeBannerAd";
 
 export default function TextSummarizerClient() {
   const [isLoading, setIsLoading] = useState(false)
@@ -58,6 +58,9 @@ export default function TextSummarizerClient() {
         <TextSummarizerForm onSubmit={handleSubmit} isLoading={isLoading} />
         <TextSummarizerOutput summary={summary} isLoading={isLoading} />
       </div>
+      {/* Ad Banner */}
+<NativeBannerAd />
+
     </div>
   )
 }

--- a/src/app/(Tools)/trip-planner/_components/trip-planner-client.tsx
+++ b/src/app/(Tools)/trip-planner/_components/trip-planner-client.tsx
@@ -14,7 +14,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { ChevronsUpDown, MapPin, Star, Clock, ThumbsUp, Plane, Settings, AlertCircle, RefreshCw, HelpCircle, FileEdit, User, FileText } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-mobile";
-
+import NativeBannerAd from "@/components/NativeBannerAd";
 export interface Activity {
   name: string;
   location: string;
@@ -214,6 +214,7 @@ export default function TripPlannerClient() {
   }, [result, error, isMobile]);
 
   return (
+    <>
     <div className="w-full max-w-4xl mx-auto">
       <section>
         <h2 className="sr-only">Trip Planning Form</h2>
@@ -274,8 +275,12 @@ export default function TripPlannerClient() {
           </CollapsibleContent>
         </Collapsible>
       </div>
-
+          
       
     </div>
+    {/* Ad Banner */}
+<NativeBannerAd />
+    </>
+
   );
 }

--- a/src/app/(Tools)/youtube-idea-generator/_components/youtube-idea-generator-client.tsx
+++ b/src/app/(Tools)/youtube-idea-generator/_components/youtube-idea-generator-client.tsx
@@ -14,7 +14,7 @@ import { Button } from "@/components/ui/button"
 import { ChevronsUpDown, Youtube, Video, Film, Camera, Play, Zap } from "lucide-react"
 import { useIsMobile } from "@/hooks/use-mobile"
 import Link from "next/link"
-
+import NativeBannerAd from "@/components/NativeBannerAd";
 export default function YouTubeIdeaGeneratorClient() {
   const [generatedIdeas, setGeneratedIdeas] = useState("")
   const [isLoading, setIsLoading] = useState(false)
@@ -216,6 +216,9 @@ Format each idea with clear sections using markdown headers (##) and bullet poin
             </div>
           </div>
         )}
+
+        {/* Ad Banner */}
+        <NativeBannerAd />
 
         {/* SEO Content - Server-side rendered */}
         <div className="mt-12 prose prose-gray max-w-none">

--- a/src/components/NativeBannerAd.tsx
+++ b/src/components/NativeBannerAd.tsx
@@ -6,9 +6,10 @@ import Script from "next/script";
 export default function NativeBannerAd() {
   return (
     <>
+    
       <Script
         id="native-banner-ad"
-        strategy="afterInteractive"
+        strategy="lazyOnload"
         src="//pl27373634.profitableratecpm.com/f74b3f2433134857ab82e88a59f9f2b2/invoke.js"
         async
         data-cfasync="false"


### PR DESCRIPTION
### feat: Update NativeBannerAd Placement on Tool Pages

**Description:**
This pull request updates the placement of the `<NativeBannerAd />` component across the tool pages to align with the latest guidelines.

* Ensures only one `<NativeBannerAd />` per tool page
* Positioned directly below the output/tool section
* Placed before the main content begins to maintain a smooth and natural user experience
* Verified that the layout remains fully responsive on both desktop and mobile devices

---

**Note:**
This is my very first open source contribution, and I am grateful for the opportunity to contribute to this project. I sincerely welcome any feedback or suggestions for improvement. Please kindly let me know if there is anything I may have missed or if any adjustments are required. I am more than happy to make any necessary changes.

Thank you very much for your time and consideration.

---

**Checklist:**

* [x] Single `<NativeBannerAd />` per tool page
* [x] Correct and thoughtful placement below the output/tool section
* [x] Layout and styling remain consistent and intact
* [x] Fully responsive design across all device sizes

